### PR TITLE
Fixes inactive outputs on plugInSideBypass

### DIFF
--- a/PluginTemplate/project_source/source/vst_source/vst3plugin.cpp
+++ b/PluginTemplate/project_source/source/vst_source/vst3plugin.cpp
@@ -908,7 +908,7 @@ tresult PLUGIN_API VST3Plugin::process(ProcessData& data)
         for (int32 sample = 0; sample < data.numSamples; sample++)
         {
             // --- output = input
-			for (unsigned int i = 0; i<info.numAuxAudioOutChannels; i++)
+			for (unsigned int i = 0; i<info.numAudioOutChannels; i++)
             {
                 (data.outputs[0].channelBuffers32[i])[sample] = (data.inputs[0].channelBuffers32[i])[sample];
             }

--- a/samples/demo_custom_views/With FFTW/DemoFFTViews/project_source/source/vst_source/vst3plugin.cpp
+++ b/samples/demo_custom_views/With FFTW/DemoFFTViews/project_source/source/vst_source/vst3plugin.cpp
@@ -908,7 +908,7 @@ tresult PLUGIN_API VST3Plugin::process(ProcessData& data)
         for (int32 sample = 0; sample < data.numSamples; sample++)
         {
             // --- output = input
-			for (unsigned int i = 0; i<info.numAuxAudioOutChannels; i++)
+			for (unsigned int i = 0; i<info.numAudioOutChannels; i++)
             {
                 (data.outputs[0].channelBuffers32[i])[sample] = (data.inputs[0].channelBuffers32[i])[sample];
             }

--- a/samples/demo_custom_views/Without FFTW/DemoCustomViews/project_source/source/vst_source/vst3plugin.cpp
+++ b/samples/demo_custom_views/Without FFTW/DemoCustomViews/project_source/source/vst_source/vst3plugin.cpp
@@ -908,7 +908,7 @@ tresult PLUGIN_API VST3Plugin::process(ProcessData& data)
         for (int32 sample = 0; sample < data.numSamples; sample++)
         {
             // --- output = input
-			for (unsigned int i = 0; i<info.numAuxAudioOutChannels; i++)
+			for (unsigned int i = 0; i<info.numAudioOutChannels; i++)
             {
                 (data.outputs[0].channelBuffers32[i])[sample] = (data.inputs[0].channelBuffers32[i])[sample];
             }

--- a/samples/demo_fx/DemoVolumePlugin/project_source/source/vst_source/vst3plugin.cpp
+++ b/samples/demo_fx/DemoVolumePlugin/project_source/source/vst_source/vst3plugin.cpp
@@ -908,7 +908,7 @@ tresult PLUGIN_API VST3Plugin::process(ProcessData& data)
         for (int32 sample = 0; sample < data.numSamples; sample++)
         {
             // --- output = input
-			for (unsigned int i = 0; i<info.numAuxAudioOutChannels; i++)
+			for (unsigned int i = 0; i<info.numAudioOutChannels; i++)
             {
                 (data.outputs[0].channelBuffers32[i])[sample] = (data.inputs[0].channelBuffers32[i])[sample];
             }


### PR DESCRIPTION
Calls to PluginSideBypass were looping over the auxillary rather than the main outputs.