### PR TITLE
Updates for VST SDK 3.7.5

### DIFF
--- a/PluginTemplate/CMakeLists.txt
+++ b/PluginTemplate/CMakeLists.txt
@@ -24,7 +24,7 @@ cmake_minimum_required (VERSION 3.4.3)
 #     NOTE: this is not needed when you export individual API projects
 set(UNI_AAX_SDK_FOLDER 		AAX_SDK)
 set(UNI_AU_SDK_FOLDER 		AU_SDK)
-set(UNI_VST3_SDK_FOLDER 	VST_SDK/VST3_SDK)
+set(UNI_VST3_SDK_FOLDER 	VST_SDK/vst3sdk)
 # ---------------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------------

--- a/PluginTemplate/project_source/cmake/vst_cmake/CMakeLists.txt
+++ b/PluginTemplate/project_source/cmake/vst_cmake/CMakeLists.txt
@@ -202,10 +202,10 @@ endif()
 # ---  Resources:
 #
 # ---------------------------------------------------------------------------------
-smtg_add_vst3_resource(${target} "${RESOURCE_ROOT}/PluginGUI.uidesc")
+smtg_target_add_plugin_resources(${target} "${RESOURCE_ROOT}/PluginGUI.uidesc")
 
 if(MAC)
-	smtg_set_bundle(${target} INFOPLIST "${CMAKE_CURRENT_LIST_DIR}/${MAC_ROOT}/Info.plist" PREPROCESS)
+	smtg_target_set_bundle(${target} INFOPLIST "${CMAKE_CURRENT_LIST_DIR}/${MAC_ROOT}/Info.plist" PREPROCESS)
 elseif(WIN)
 	target_sources(${target} PRIVATE ${WIN_ROOT}/PluginGUIMain.rc)
 	target_sources(${target} PRIVATE ${RESOURCE_ROOT}/PluginGUI.uidesc)
@@ -229,7 +229,7 @@ endif()
 
 # --- add post build rule to copy VST3 icon for bundle appearance of folder
 if(WIN)
-    set(DEFAULT_ICON_PATH ${SDK_ROOT}/vst3_doc/artwork/VST_Logo_Steinberg.ico)
+    set(DEFAULT_ICON_PATH ${SDK_ROOT}/doc/artwork/VST_Logo_Steinberg.ico)
     set(PROJECT_SOURCE_DIR ${SDK_ROOT})
     set(MSG_ICON_PATH "Path to the package icon (VST_Logo_Steinberg.ico) for Windows")
     if(EXISTS ${DEFAULT_ICON_PATH})
@@ -240,7 +240,7 @@ if(WIN)
     endif()
 
     # --- add the post build rule here:
-    smtg_add_folder_icon(${target} ${SMTG_PACKAGE_ICON_PATH})
+    smtg_target_add_folder_icon(${target} ${SMTG_PACKAGE_ICON_PATH})
 endif()
 
 source_group(PluginKernel FILES ${kernel_sources})

--- a/PluginTemplate/project_source/source/CustomControls/customcontrols.cpp
+++ b/PluginTemplate/project_source/source/CustomControls/customcontrols.cpp
@@ -210,6 +210,11 @@ CAnimKnobEx::CAnimKnobEx (const CRect& size, IControlListener* listener, int32_t
 {
 	maxControlValue = 1.0;
     aaxKnob = false;
+	coef = 1.0;
+	fEntryState = 0.0;
+	modeLinear = true;
+	range = 1.0;
+	startValue = 0.0;
 }
 CAnimKnobEx::~CAnimKnobEx(void)
 {
@@ -397,6 +402,9 @@ CVerticalSliderEx::CVerticalSliderEx(const CRect &rect, IControlListener* listen
 	switchSlider = false;
     aaxSlider = false;
 	maxControlValue = 1.0;
+	delta = CCoord(0.1);
+	oldVal = 0.0;
+	startVal = 0.0;
 }
 
 CVerticalSliderEx::~CVerticalSliderEx()
@@ -468,6 +476,9 @@ CHorizontalSliderEx::CHorizontalSliderEx (const CRect &rect, IControlListener* l
 	switchSlider = false;
     aaxSlider = false;
 	maxControlValue = 1.0;
+	delta = CCoord(0.1);
+	oldVal = 0.0;
+	startVal = 0.0;
 }
 CHorizontalSliderEx::~CHorizontalSliderEx()
 {

--- a/PluginTemplate/project_source/source/CustomControls/customcontrols.h
+++ b/PluginTemplate/project_source/source/CustomControls/customcontrols.h
@@ -175,7 +175,7 @@ public:
 	*/
 	virtual CMouseEventResult onMouseMoved (CPoint& where, const CButtonState& buttons) override;
 
-    bool checkDefaultValue (CButtonState button) override;
+	bool checkDefaultValue (CButtonState button);
 	virtual void valueChanged() override;
 
 	/**
@@ -258,7 +258,7 @@ public:
 	*/
 	virtual CMouseEventResult onMouseMoved (CPoint& where, const CButtonState& buttons) override;
 
-	bool checkDefaultValue (CButtonState button) override;
+	bool checkDefaultValue (CButtonState button);
 
 	/**
 	\brief set max discrete switching value
@@ -345,7 +345,7 @@ public:
 	*/
 	virtual CMouseEventResult onMouseMoved (CPoint& where, const CButtonState& buttons) override;
 
-	bool checkDefaultValue (CButtonState button) override;
+	bool checkDefaultValue (CButtonState button);
 
 	/**
 	\brief set max discrete switching value
@@ -577,14 +577,15 @@ public:
     // --- for vector joystick operation
 	inline int pointInPolygon(int nvert, float *vertx, float *verty, float testx, float testy)
 	{
-		int i, j, c = 0;
+		bool c = false;
+		int i, j;
 		for (i = 0, j = nvert-1; i < nvert; j = i++)
 		{
 			if ( ((verty[i]>testy) != (verty[j]>testy)) &&
 				(testx < (vertx[j]-vertx[i]) * (testy-verty[i]) / (verty[j]-verty[i]) + vertx[i]) )
 			c = !c;
 		}
-	 return c;
+	 return c?1:0;
 	}
 
     static void calculateXY (float value, float& x, float& y)

--- a/PluginTemplate/project_source/source/PluginKernel/plugingui.cpp
+++ b/PluginTemplate/project_source/source/PluginKernel/plugingui.cpp
@@ -2455,7 +2455,7 @@ Operation:\n
 IController* PluginGUI::createSubController(UTF8StringPtr name, const IUIDescription* description)
 {
 	std::string strName(name);
-	int findIt = strName.find("KnobLinkController");
+	int findIt = (int)strName.find("KnobLinkController");
 	if (findIt >= 0)
 	{
 		// --- create the sub-controller
@@ -2647,6 +2647,53 @@ CMouseEventResult PluginGUI::onMouseMoved(CFrame* frame, const CPoint& where, co
 	return result;
 }
 
+
+/**
+\brief helper method to convert a MouseEventButtonState to the (old?) CButtonState
+
+\param state the MouseEventButtonState to convert
+
+\result an equivalent CButtonState object
+*/
+CButtonState PluginGUI::convertButtonState(MouseEventButtonState& state)
+{
+	uint32_t btnState = 0;
+	if (state.is(VSTGUI::MouseButton::Left))
+		btnState |= kLButton;
+	if (state.is(VSTGUI::MouseButton::Middle))
+		btnState |= kMButton;
+	if (state.is(VSTGUI::MouseButton::Right))
+		btnState |= kRButton;
+	if (state.is(VSTGUI::MouseButton::Fourth))
+		btnState |= kButton4;
+	if (state.is(VSTGUI::MouseButton::Fifth))
+		btnState |= kButton5;
+	return CButtonState(btnState);
+}
+
+/**
+\brief message handler for consolidated mouse down and move event\n
+This should be refactored by someone who knows how it /should/ work
+
+Operation:\n
+
+\param event the mouse event
+\param frame the owning frame
+*/
+void PluginGUI::onMouseEvent(MouseEvent& event, CFrame* frame)
+{
+	const CButtonState& btnState = convertButtonState(event.buttonState);
+	if (event.type == VSTGUI::EventType::MouseMove)
+	{
+		CMouseEventResult result = onMouseMoved(frame, event.mousePosition, btnState);
+		event.consumed = (result == CMouseEventResult::kMouseEventHandled);
+	}
+	else if (event.type == VSTGUI::EventType::MouseDown)
+	{
+		CMouseEventResult result = onMouseDown(frame, event.mousePosition, btnState);
+		event.consumed = (result == CMouseEventResult::kMouseEventHandled);
+	}
+}
 
 // --- VSTGUI4 Initialization/De-initialization ------------------------- //
 /**

--- a/PluginTemplate/project_source/source/PluginKernel/plugingui.h
+++ b/PluginTemplate/project_source/source/PluginKernel/plugingui.h
@@ -706,17 +706,26 @@ public:
 	/** IMouseObserver override not used */
 	void onMouseExited(CView* view, CFrame* frame) override {}
 
-	/** IMouseObserver mouse moved handler */
-	CMouseEventResult onMouseDown(CFrame* frame, const CPoint& where, const CButtonState& buttons) override;
+	/** DEPRECATED IMouseObserver mouse moved handler */
+	CMouseEventResult onMouseDown(CFrame* frame, const CPoint& where, const CButtonState& buttons);
 
-	/** IMouseObserver mouse moved handler */
-	CMouseEventResult onMouseMoved(CFrame* frame, const CPoint& where, const CButtonState& buttons) override;
+	/** DEPRECATED IMouseObserver mouse moved handler */
+	CMouseEventResult onMouseMoved(CFrame* frame, const CPoint& where, const CButtonState& buttons);
+
+	/** Helper method for the change to MouseEventButtonState */
+	CButtonState convertButtonState(MouseEventButtonState& state);
+
+	/** IMouseObserver mouse event handler */
+	void onMouseEvent(MouseEvent& event, CFrame* frame) override;
 
 	/** IKeyboardHook key down handler, not used */
-	int32_t onKeyDown(const VstKeyCode& code, CFrame* frame) override { return -1; }
+	int32_t onKeyDown(const VstKeyCode& code, CFrame* frame) { return -1; }
 
 	/** IKeyboardHook key up handler, not used */
-	int32_t onKeyUp(const VstKeyCode& code, CFrame* frame) override { return -1; }
+	int32_t onKeyUp(const VstKeyCode& code, CFrame* frame) { return -1; }
+
+	/** IKeyboardHook key event handler */
+	void onKeyboardEvent(KeyboardEvent& event, CFrame* frame) override {}
 
 	/** ICommandMenuItemTarget called before the item is shown to validate its state */
 	virtual bool validateCommandMenuItem(CCommandMenuItem* item) override;

--- a/PluginTemplate/project_source/source/PluginKernel/pluginstructures.h
+++ b/PluginTemplate/project_source/source/PluginKernel/pluginstructures.h
@@ -752,7 +752,10 @@ WAV files for sample based synths.
 */
 struct PluginInfo
 {
-	PluginInfo() {}
+	PluginInfo()
+	{
+		pathToDLL = "";
+	}
 
 	PluginInfo& operator=(const PluginInfo& data)	// need this override for collections to work
 	{

--- a/PluginTemplate/project_source/source/vst_source/vst3plugin.cpp
+++ b/PluginTemplate/project_source/source/vst_source/vst3plugin.cpp
@@ -46,6 +46,7 @@ VST3Plugin::VST3Plugin()
     processContextRequirements.wantsTimeSignature();
     processContextRequirements.wantsContinousTimeSamples();
     processContextRequirements.wantsSystemTime();
+	selectedUnit = Steinberg::Vst::UnitID(0);
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -987,7 +988,7 @@ tresult PLUGIN_API VST3Plugin::process(ProcessData& data)
         for (int32 sample = 0; sample < data.numSamples; sample++)
         {
             // --- output = input
-			for (unsigned int i = 0; i<info.numAuxAudioOutChannels; i++)
+			for (unsigned int i = 0; i<info.numAudioOutChannels; i++)
             {
                 (data.outputs[0].channelBuffers32[i])[sample] = (data.inputs[0].channelBuffers32[i])[sample];
             }
@@ -1347,7 +1348,7 @@ tresult PLUGIN_API VST3Plugin::getProgramName(ProgramListID listId, int32 progra
 		{
 			ParamValue normalized = param->toNormalized (programIndex);
 			param->toString (normalized, name);
-            const char* pp = pluginCore->getPresetName(programIndex);
+            pluginCore->getPresetName(programIndex);
 
 			return kResultTrue;
 		}
@@ -1524,6 +1525,7 @@ VSTParamUpdateQueue::VSTParamUpdateQueue(void)
 	y2 = 0.0;
 	slope = 1.0;
 	dirtyBit = false;
+	yIntercept = Steinberg::Vst::ParamValue(0.0);
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1785,7 +1787,7 @@ PluginEditor::PluginEditor(VSTGUI::UTF8StringPtr _xmlFile, PluginCore* _pluginCo
 , pluginHostConnector(_pluginHostConnector)
 , editController(_editController)
 {
-
+	plugFrame = NULL;
 }
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //	PluginEditor::~PluginEditor

--- a/PluginTemplate/project_source/source/vst_source/vst3plugin.h
+++ b/PluginTemplate/project_source/source/vst_source/vst3plugin.h
@@ -783,7 +783,7 @@ public:
     {
         if (sampleOffset == 0 && pluginCore)
         {
-            uint32_t count = proxyMIDIEvents.size();
+            uint32_t count = (uint32_t)proxyMIDIEvents.size();
             for (uint32_t i = 0; i < count; i++)
             {
                 pluginCore->processMIDIEvent(proxyMIDIEvents[i]);


### PR DESCRIPTION
I'm still finding my way around the VST SDK and ASPiK so I'm hoping this is helpful in bringing the ASPiK framework towards VST 3.7.5 compatibility.
I can now build a plugin, though I still have to manually move moduleinfotool.exe to the same location as validator.exe, and edit the post build steps to include a Version in the moduleinfotoool args.  I don't understand cmake well enough to diagnose those.

Some edits were just to reduce the compiler warnings.